### PR TITLE
fix: correct the src directory in the transform complete message

### DIFF
--- a/src/builders/transform.ts
+++ b/src/builders/transform.ts
@@ -62,7 +62,7 @@ export async function transformDir(
   await Promise.all(promises);
 
   consola.log(
-    `Transformed ${promises.length} files from \`${fmtPath(entry.outDir!)}\` to \`${fmtPath(entry.outDir!)}\` in ${Date.now() - start}ms`,
+    `Transformed ${promises.length} files from \`${fmtPath(entry.input!)}\` to \`${fmtPath(entry.outDir!)}\` in ${Date.now() - start}ms`,
   );
 }
 


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Previously the message used the output directory for both the from and to.

Before: "Transformed 119 files from ./dist to ./dist in 89ms"

After: "Transformed 119 files from ./src to ./dist in 62ms"