### PR TITLE
refactor: switch to tinyglobby

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "oxc-parser": "^0.69.0",
     "oxc-transform": "^0.69.0",
     "rolldown": "npm:rolldown@1.0.0-beta.8-commit.d95f99e",
-    "rolldown-plugin-dts": "^0.12.1"
+    "rolldown-plugin-dts": "^0.12.1",
+    "tinyglobby": "^0.2.13"
   },
   "devDependencies": {
     "@types/node": "^22.15.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       rolldown-plugin-dts:
         specifier: ^0.12.1
         version: 0.12.1(rolldown@1.0.0-beta.8-commit.d95f99e)(typescript@5.8.3)
+      tinyglobby:
+        specifier: ^0.2.13
+        version: 0.2.13
     devDependencies:
       '@types/node':
         specifier: ^22.15.17

--- a/src/builders/transform.ts
+++ b/src/builders/transform.ts
@@ -9,6 +9,7 @@ import MagicString from "magic-string";
 import oxcTransform from "oxc-transform";
 import oxcParser from "oxc-parser";
 import { fmtPath } from "../utils.ts";
+import { glob } from "tinyglobby";
 
 /**
  * Transform all .ts modules in a directory using oxc-transform.
@@ -21,9 +22,7 @@ export async function transformDir(
 
   const promises: Promise<void>[] = [];
 
-  const { glob } = await import("node:fs/promises");
-
-  for await (const entryName of glob("**/*.*", { cwd: entry.input })) {
+  for await (const entryName of await glob("**/*.*", { cwd: entry.input })) {
     promises.push(
       (async () => {
         const entryPath = join(entry.input, entryName);


### PR DESCRIPTION
fixes #21 

glob is only supported from [Node 22+](https://nodejs.org/docs/latest-v22.x/api/fs.html#fspromisesglobpattern-options), `tinyglobby` allows supported older Node releases.