### PR TITLE
feat: passthrough stub mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,17 @@ The **obuild** project aims to be the next-generation successor to the current [
 - 🪦 No support for CommonJS output.
 
 Some differences are not easy to adopt. Developing as a standalone project allows for faster progress and dogfooding in real projects.
- 
+
 👀 See [this issue](https://github.com/unjs/obuild/issues/24) for more explanation about the difference between `obuild`, `unbuild`, `tsup`, and `tsdown`.
+
+## Currently used by
+
+- [📦 obuild](https://github.com/unjs/obuild/)
+- [🌳 rou3](https://github.com/h3js/rou3/)
+- [💥 srvx](https://github.com/h3js/srvx)
+- [🕊️ unenv](https://github.com/unjs/unenv)
+- [🕰️ omnichron](https://github.com/oritwoen/omnichron)
+- [...add yours...]
 
 ## Usage
 
@@ -41,14 +50,27 @@ await build(".", ["./src/index.ts"]);
 > [!NOTE]
 > Auto entries inference similar to unbuild coming soon ([#4](https://github.com/unjs/obuild/issues/4)).
 
-## Currently used by
+## Stub Mode
 
-- [📦 obuild](https://github.com/unjs/obuild/)
-- [🌳 rou3](https://github.com/h3js/rou3/)
-- [💥 srvx](https://github.com/h3js/srvx)
-- [🕊️ unenv](https://github.com/unjs/unenv)
-- [🕰️ omnichron](https://github.com/oritwoen/omnichron)
-- [...add yours...]
+When working on a package locally, it can be tedious to rebuild or run the watch command every time.
+
+You can use `stub: true` (per entry config) or the `--stub` CLI flag. In this mode, obuild skips the actual build and instead links the expected dist paths to the source files.
+
+- For bundle entries, `.mjs` and `.d.mts` files re-export the source file.
+- For transpile entries, src dir is symlinked to dist.
+
+**Caveats:**
+
+- You need a runtime that natively supports TypeScript. Deno, Bun, Vite, and Node.js (1)
+- For transpile mode, you need to configure your bundler to resolve either `.ts` or `.mjs` extensions.
+- For bundle mode, if you add a new entry or add/remove a `default` export, you need to run the stub build again.
+
+(1) For Node.js, you have several options:
+
+- Using `--experimental-strip-types` or `NODE_OPTIONS="--experimental-strip-types"`
+- Using [jiti](https://github.com/unjs/jiti) (`node --import jiti/register`)
+- Using [oxc-node](https://github.com/oxc-project/oxc-node) (`node --import @oxc-node/core/register`)
+- Using [unloader](https://github.com/sxzz/unloader) (`node --import unloader/register`)
 
 ## Proof of concept
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You can use `stub: true` (per entry config) or the `--stub` CLI flag. In this mo
 
 (1) For Node.js, you have several options:
 
-- Using `--experimental-strip-types` or `NODE_OPTIONS="--experimental-strip-types"`
+- Using `node --experimental-strip-types` (Available in [22.6](https://nodejs.org/en/blog/release/v22.6.0))
 - Using [jiti](https://github.com/unjs/jiti) (`node --import jiti/register`)
 - Using [oxc-node](https://github.com/oxc-project/oxc-node) (`node --import @oxc-node/core/register`)
 - Using [unloader](https://github.com/sxzz/unloader) (`node --import unloader/register`)

--- a/src/builders/transform.ts
+++ b/src/builders/transform.ts
@@ -4,7 +4,7 @@ import type { MinifyOptions } from "oxc-minify";
 
 import { pathToFileURL } from "node:url";
 import { dirname, extname, join, relative } from "node:path";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, symlink, writeFile } from "node:fs/promises";
 import { consola } from "consola";
 import { colors as c } from "consola/utils";
 import { resolveModulePath } from "exsolve";
@@ -22,6 +22,14 @@ export async function transformDir(
   ctx: BuildContext,
   entry: TransformEntry,
 ): Promise<void> {
+  if (entry.stub) {
+    consola.log(
+      `${c.magenta("[transform] [stub]   ")} ${c.underline(fmtPath(entry.outDir!) + "/")}`,
+    );
+    await symlink(entry.input, entry.outDir!, "junction");
+    return;
+  }
+
   const promises: Promise<string>[] = [];
 
   for await (const entryName of await glob("**/*.*", { cwd: entry.input })) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,10 @@ const args = parseArgs({
       type: "string",
       default: ".",
     },
+    stub: {
+      type: "boolean",
+      default: false,
+    },
   },
 });
 
@@ -41,6 +45,12 @@ const entries: BuildEntry[] = rawEntries.map((entry) => {
   }
   return entry;
 });
+
+if (args.values.stub) {
+  for (const entry of entries) {
+    entry.stub = true;
+  }
+}
 
 if (rawEntries.length === 0) {
   consola.error("No build entries specified.");

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,20 +14,27 @@ export interface BuildContext {
   pkg: { name: string } & Record<string, unknown>;
 }
 
-export type BundleEntry = {
-  type: "bundle";
-
-  /**
-   * Entry point(s) to bundle relative to the project root.
-   * */
-  input: string | string[];
-
+export type _BuildEntry = {
   /**
    * Output directory relative to project root.
    *
    * Defaults to `dist/` if not provided.
    */
   outDir?: string;
+
+  /**
+   * Avoid actual build but instead link to the source files.
+   */
+  stub?: boolean;
+};
+
+export type BundleEntry = _BuildEntry & {
+  type: "bundle";
+
+  /**
+   * Entry point(s) to bundle relative to the project root.
+   * */
+  input: string | string[];
 
   /**
    * Minify the output using rolldown.
@@ -44,20 +51,13 @@ export type BundleEntry = {
   declaration?: boolean | IsolatedDeclarationsOptions;
 };
 
-export type TransformEntry = {
+export type TransformEntry = _BuildEntry & {
   type: "transform";
 
   /**
    * Directory to transform relative to the project root.
    */
   input: string;
-
-  /**
-   * Output directory relative to project root.
-   *
-   * Defaults to `dist/` if not provided.
-   */
-  outDir?: string;
 
   /**
    * Minify the output using oxc-minify.

--- a/test/fixture/src/index.ts
+++ b/test/fixture/src/index.ts
@@ -1,3 +1,5 @@
 export function test() {
   return "test bundled";
 }
+
+export default "default export";

--- a/test/fixture/src/runtime/index.ts
+++ b/test/fixture/src/runtime/index.ts
@@ -1,1 +1,3 @@
 export { test } from "./test.ts";
+
+export default "default export";


### PR DESCRIPTION
resolves #3

similar feature of unbuild to build with stub mode.

Main difference is that obuild uses passthrough reexports that natively work with runtime (Deno, Bun or Vite).

For Node.js, jiti, oxc-node or unloader can be enabled using `node --import` or using `--experimental-strip-types`