### PR TITLE
feat: allow passing oxc-transform options for build entries

### DIFF
--- a/src/builders/bundle.ts
+++ b/src/builders/bundle.ts
@@ -70,6 +70,7 @@ export async function rolldownBuild(
     input: inputs,
     plugins: [shebangPlugin()] as Plugin[],
     platform: "neutral",
+    transform: entry.oxc,
     external: [
       ...builtinModules,
       ...builtinModules.map((m) => `node:${m}`),

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,13 @@ export type BundleEntry = _BuildEntry & {
    * Set to `false` to disable.
    */
   dts?: boolean | DtsOptions;
+
+  /**
+   * Options passed to oxc-transform.
+   *
+   * See [oxc-transform](https://www.npmjs.com/package/oxc-transform) for more details.
+   */
+  oxc?: TransformOptions;
 };
 
 export type TransformEntry = _BuildEntry & {
@@ -69,13 +76,6 @@ export type TransformEntry = _BuildEntry & {
    * Defaults to `false` if not provided.
    */
   minify?: boolean | OXCMinifyOptions;
-
-  /**
-   * Options passed to oxc-transform.
-   *
-   * See [oxc-transform](https://www.npmjs.com/package/oxc-transform) for more details.
-   */
-  oxc?: TransformOptions;
 };
 
 export type BuildEntry = BundleEntry | TransformEntry;


### PR DESCRIPTION
> Could we include this also for build entries? 
> 
> Or at least some of it's options like `decorator` would be great. 

 _Originally posted by @zsilbi in [5729956](https://github.com/unjs/obuild/commit/57299566d97ba7f7abaa782731c8e549be3ce7ee#r158103123)_