### PR TITLE
fix: programmatic build with string entries

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -33,12 +33,19 @@ export async function build(config: BuildConfig): Promise<void> {
 
   await hooks.start?.(ctx);
 
-  const entries = (config.entries || []).map((entry) => {
-    if (typeof entry === "string") {
-      const [input, outDir] = entry.split(":") as [string, string | undefined];
-      return input.endsWith("/")
+  const entries = (config.entries || []).map((rawEntry) => {
+    let entry: TransformEntry | BundleEntry;
+
+    if (typeof rawEntry === "string") {
+      const [input, outDir] = rawEntry.split(":") as [
+        string,
+        string | undefined,
+      ];
+      entry = input.endsWith("/")
         ? ({ type: "transform", input, outDir } as TransformEntry)
         : ({ type: "bundle", input: input.split(","), outDir } as BundleEntry);
+    } else {
+      entry = rawEntry;
     }
 
     if (!entry.input) {

--- a/test/fixture/src/utils.ts
+++ b/test/fixture/src/utils.ts
@@ -1,0 +1,5 @@
+export function test() {
+  return "utils bundled";
+}
+
+export default "default utils export";

--- a/test/obuild.test.ts
+++ b/test/obuild.test.ts
@@ -17,6 +17,7 @@ describe("obuild", () => {
       entries: [
         { type: "bundle", input: ["src/index", "src/cli"] },
         { type: "transform", input: "src/runtime", outDir: "dist/runtime" },
+        "src/utils.ts",
       ],
     });
   });
@@ -36,6 +37,8 @@ describe("obuild", () => {
         "runtime/index.mjs",
         "runtime/test.d.mts",
         "runtime/test.mjs",
+        "utils.d.mts",
+        "utils.mjs",
       ]
     `);
   });
@@ -46,6 +49,9 @@ describe("obuild", () => {
 
     const distRuntimeIndex = await import(new URL("index.mjs", distDir).href);
     expect(distRuntimeIndex.test).instanceOf(Function);
+    
+    const distUtils = await import(new URL("utils.mjs", distDir).href);
+    expect(distUtils.test).instanceOf(Function);
   });
 
   test("runtime .dts files use .mjs extension", async () => {


### PR DESCRIPTION
The entries are now pre-processed before the `build()` function is called from the `cli`.

But using
```ts
import { build } from "obuild";

await build({
  cwd: ".",
  entries: ["./src/index.ts"],
});
``` 

fails with this error:

```
node:path:1181
      validateString(path, `paths[${i}]`);
      ^

TypeError [ERR_INVALID_ARG_TYPE]: The "paths[0]" argument must be of type string. Received undefined
```

because the `outDir` is missing for the provided `entries`.