### PR TITLE
docs: add UnOJ to users

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ Some differences are not easy to adopt. Developing as a standalone project allow
 
 ## Currently used by
 
-- [📦 obuild](https://github.com/unjs/obuild/)
-- [🌳 rou3](https://github.com/h3js/rou3/)
+- [📦 obuild](https://github.com/unjs/obuild)
+- [🌳 rou3](https://github.com/h3js/rou3)
 - [💥 srvx](https://github.com/h3js/srvx)
 - [🕊️ unenv](https://github.com/unjs/unenv)
 - [🕰️ omnichron](https://github.com/oritwoen/omnichron)
+- [✅ UnOJ](https://github.com/un-oj/core)
 - [...add yours...]
 
 ## Usage


### PR DESCRIPTION
Done in https://github.com/un-oj/core/commit/7b26b71c605660031d22fc20dbc35ff6eb7799b5 ✨5359ms →1208ms (including shell overhead)

BTW I see it copies (and add incorrect `\n`s) to both `.mjs` and `.d.mts`:

```ts
/** Get the first key of an object. */
export declare function getFirstKey<T extends Record<never, never>>(obj: T): keyof T;
```

```js
/** Get the first key of an object. */
export function getFirstKey(obj) {
	return Object.keys(obj)[0];
}
```

Is this expected?